### PR TITLE
Fix: restrict review's delete button visibility to review owner only

### DIFF
--- a/views/listings/show.ejs
+++ b/views/listings/show.ejs
@@ -130,6 +130,8 @@
             data-rating="<%= review.rating %>"
           ></p>
           <p class="card-text"><%= review.comment %></p>
+
+          <% if(currentUser && review.author._id.equals(currentUser._id)) { %>
           <form
             method="POST"
             action="/listings/<%= listing._id %>/reviews/<%= review._id %>?_method=DELETE"
@@ -137,6 +139,7 @@
           >
             <button class="btn btn-sm btn-danger m-1 position-absolute bottom-0 start-10">Delete</button>
           </form>
+          <% } %>
         </div>
       </div>
       <% } %>


### PR DESCRIPTION
🐛 ### Problem

The delete button for reviews was being displayed to all users, regardless of whether they were the author of the review or not. This could lead to confusion.

✅ ### Solution

- Added a conditional check in the EJS template.

- Now, the delete button is only rendered if: the logged-in user is the author of that review.

Updated show.ejs to wrap the delete button with an if condition:### 
<% if(currentUser && review.author._id.equals(currentUser._id)) { %>
   <!-- delete button-->
<% } %>


---
## EntelligenceAI PR Summary 
 This PR restricts review deletion controls to authorized users in the listing details view.
- Updated `views/listings/show.ejs` to conditionally display the 'Delete' button and form only for logged-in users who authored the review. 

