### PR TITLE
About us is now redirecting to about page

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,6 +166,11 @@ app.use("/listings", listingRouter);
 app.use("/listings/:id/reviews", reviewRouter);
 app.use("/", userRouter);
 
+app.get("/about", (req, res) => {
+  res.render("about", { title: "About Us" });
+});
+
+
 app.all("*", (req, res, next) => {
     next(new ExpressError(404, "Page Not Found"));
 });

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -1,0 +1,91 @@
+<% layout("/layouts/boilerplate") %>
+
+<div class="container" style="max-width:1000px;margin:auto;padding:40px;line-height:1.8;">
+  <h1 class="text-3xl font-bold mb-6">About Wanderlust</h1>
+  
+  <p>
+    Welcome to <strong>Wanderlust</strong>, a community-driven platform built to inspire 
+    and empower travelers. We believe every journey has the power to connect people, 
+    spark creativity, and create unforgettable stories. Our vision is simple: 
+    to help you <em>feel at home, anywhere in the world</em>.
+  </p>
+
+  <h2 class="text-2xl font-semibold mt-8 mb-3">🌍 Our Mission</h2>
+  <p>
+    Wanderlust isn’t just about finding a place to stay—it’s about discovering places 
+    that feel like they were meant for you. From city lofts to countryside retreats, 
+    we make travel accessible, safe, and truly memorable. 
+    Our mission is to connect curious travelers with passionate hosts and experiences 
+    that go beyond walls and roofs.
+  </p>
+
+  <h2 class="text-2xl font-semibold mt-8 mb-3">💡 Our Story</h2>
+  <p>
+    Born from the idea that travel should be more personal and less transactional, 
+    Wanderlust was created by a small group of developers and explorers who wanted 
+    to reimagine how people travel. Inspired by platforms like Airbnb, we designed 
+    Wanderlust with simplicity, trust, and community at its core.
+  </p>
+
+  <h2 class="text-2xl font-semibold mt-8 mb-3">✨ Why Choose Wanderlust?</h2>
+  <ul style="margin-left:20px;list-style:disc;">
+    <li>Handpicked stays that fit every style and budget</li>
+    <li>Trusted hosts and verified listings for peace of mind</li>
+    <li>Seamless booking with secure payments</li>
+    <li>Personalized experiences designed for modern travelers</li>
+  </ul>
+
+  <h2 class="text-2xl font-semibold mt-8 mb-3">🤝 Our Values</h2>
+  <p>
+    We are guided by three simple values: <strong>Trust, Belonging, and Adventure</strong>.  
+    Wanderlust is more than a website—it’s a community. We believe in creating spaces 
+    where every traveler feels welcome, and every host feels supported.
+  </p>
+
+  <h2 class="text-2xl font-semibold mt-8 mb-3">🚀 Join the Journey</h2>
+  <p>
+    Whether you’re looking for your next destination or opening your doors to the world, 
+    Wanderlust is here to make it possible. Together, let’s redefine what it means 
+    to travel and belong anywhere.
+  </p>
+
+  <a href="/listings" class="btn">Book your Hotel</a>
+</div>
+
+
+
+
+<style>
+.container {
+  line-height: 1.6;
+}
+
+h1, h2 {
+  color: #fe424d;
+  margin-bottom: 15px;
+}
+
+ul {
+  margin-left: 20px;
+
+}
+.btn{
+    background-color: #fe424d;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 20px;
+  background-color: #ff5a5f;
+  color: white;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: bold;
+  outline: none;
+}
+
+.btn:hover {
+  background-color: #430000;
+}
+
+</style>


### PR DESCRIPTION
solved #95 

This PR introduces a new **About Us** page to the project, providing visitors with information about our mission, vision, and values.  
It adds an EJS template for the page, an Express route, and ensures navigation is working.

### Changes
- Created `views/about.ejs` with professional About Us content
- Added `/about` route in Express (`app.js`)


https://github.com/user-attachments/assets/d1c09ef7-46fb-411f-8fe9-d16dbb4693e2

Hello @koushik369mondal Please add label in it Thank You!