### PR TITLE
Add Terms & Conditions Page + Glassmorphism Effect

### DIFF
--- a/app.js
+++ b/app.js
@@ -174,6 +174,10 @@ app.get("/privacy", (req, res) => {
   res.render("privacy", { title: "Privacy Policy" });
 });
 
+app.get("/terms", (req, res) => {
+  res.render("termCondition", { title: "Term & Condition" });
+});
+
 app.all("*", (req, res, next) => {
     next(new ExpressError(404, "Page Not Found"));
 });

--- a/public/CSS/style.css
+++ b/public/CSS/style.css
@@ -289,7 +289,8 @@ body {
 
 .error-card,
 .create-container,
-.privecy-container{
+.privecy-container,
+.term-container{
   border: none !important;
   background: transparent;
   -webkit-backdrop-filter: blur(10px);

--- a/views/termCondition.ejs
+++ b/views/termCondition.ejs
@@ -1,0 +1,58 @@
+<% layout("/layouts/boilerplate") %>
+
+<div class="term-container" style="max-width:1000px;margin:auto;padding:40px;line-height:1.8;">
+    <h1 class="text-3xl font-bold mb-6">Terms & Conditions – Wanderlust</h1>
+    <p>Welcome to<strong> Wanderlust!</strong> By using our website, you agree to the following terms
+         and conditions. Please read them carefully.</p>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">1. Acceptance of Terms</h2>
+    <p>By accessing or using our website, you agree to comply with and be bound by these Terms & Conditions.
+         If you do not agree, please do not use our site.</p>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">2. Use of Website</h2>
+    <ul>
+        <li>You must be at least 18 years old or use the site under the supervision of a parent/guardian.</li>
+        <li>You agree not to use the website for any illegal or unauthorized purposes.</li>
+        <li>You may not attempt to harm, hack, or disrupt the functioning of the website.</li>
+    </ul>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">3. Accounts & Registration</h2>
+    <ul>
+        <li>Some features may require you to create an account.</li>
+        <li>You are responsible for keeping your login details confidential.</li>
+        <li>Wanderlust is not liable for any loss or damage caused by unauthorized account access.</li>
+    </ul>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">4. Content & Intellectual Property</h2>
+    <ul>
+        <li>All text, images, logos, and content on Wanderlust belong to us unless stated otherwise.</li>
+        <li>You may not copy, reproduce, or distribute any content without permission.</li>
+        <li>User-generated content (reviews, comments, photos) may be used by Wanderlust for promotional purposes.</li>
+    </ul>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">5. Third-Party Links</h2>
+    <p>Our website may contain links to external websites. Wanderlust is not responsible for the content, services, or practices of these third-party sites.</p>
+
+    <h2 class="text-2xl font-semibold mt-8 mb-3">6. Changes to Terms</h2>
+    <p>We may update these Terms & Conditions at any time. Continued use of our website means you accept the updated terms.</p>
+
+</div>
+
+
+  <style>
+  
+    h1,
+    h2 {
+      color: #fe424d;
+      margin-bottom: 15px;
+    }
+
+    p {
+      margin: 8px 0;
+    }
+
+    ul {
+      margin: 10px 0 20px 20px;
+    }
+
+  </style>


### PR DESCRIPTION
solved #143 

Summary

This PR adds a dedicated Terms & Conditions page to the Wanderlust site and implements a glassmorphism UI effect on the Terms page.


https://github.com/user-attachments/assets/29710d55-753b-4279-9131-bef9f4bd1057





Hello @koushik369mondal ,Please add label in it Thank You!



---
## EntelligenceAI PR Summary 
 This PR adds a complete Terms & Conditions page to the Wanderlust application.
- Added '/terms' route handler in app.js to render the new view
- Extended CSS styling in style.css to include the term container with consistent visual effects
- Created termCondition.ejs template with comprehensive legal content including usage rules, account policies, and IP rights
- Maintained visual consistency with existing pages through matching color scheme (#fe424d) and styling patterns 

