### PR TITLE
fixed dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,15 @@ updates:
           - "*"
         update-types:
           - "security-update"
+      production-dependencies:
+        patterns:
+          - "express*"
+          - "mongoose*"
+          - "passport*"
+          - "cloudinary*"
+          - "multer*"
+          - "ejs*"
+          - "bootstrap*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
closes #158
 GitHub Repository Checks:
Go to your GitHub repo → Settings → Security & analysis

Look for "Dependabot alerts" and "Dependabot security updates" (should be enabled)

Check Insights → Dependency graph → Dependabot tab

2. Validate Configuration:
# Check YAML syntax locally
npx js-yaml .github/dependabot.yml

Copy
3. Force Trigger (if needed):
Go to repo → Insights → Dependency graph → Dependabot

Click "Last checked X time ago" → Check for updates

4. Expected Behavior:
First run: Within 24 hours of pushing the config

Weekly runs: Every Monday at 9:00 AM

Security updates: Immediate when vulnerabilities found

5. Check for PRs:
Look for PRs with titles like: deps: bump express from 4.x.x to 4.y.y

PRs will have dependencies and automated labels

@koushik369mondal will be assigned as reviewer

6. Troubleshooting:
If no PRs appear after 24-48 hours:

Check if dependencies are already up-to-date: npm outdated

Verify GitHub Actions are enabled in repo settings

Check repository has package.json in root directory



@koushik369mondal please check it..