### PR TITLE
[skip-screenshot] fix : fading of text in vacation slots

### DIFF
--- a/views/users/vacation-slots.ejs
+++ b/views/users/vacation-slots.ejs
@@ -130,6 +130,8 @@
 .vacation-slots-container {
     min-height: 100vh;
     padding: 2rem 0;
+    color: white;
+    -webkit-text-fill-color: aliceblue;
 
 }
 
@@ -140,12 +142,20 @@
     margin-bottom: 30px;
     box-shadow: 0 4px 20px rgba(0,0,0,0.1);
     border: 1px solid var(--border-color);
+    -webkit-text-fill-color: aliceblue;
+    text-shadow: 2px 2px 5px black;
+
+    font-weight : bold;
+
 }
 
 .vacation-slots-header h1 {
     color: var(--text-primary);
     font-weight: 700;
     margin-bottom: 1rem;
+
+
+
 }
 
 .vacation-slot-card {
@@ -157,25 +167,32 @@
     border-left: 4px solid var(--accent-color);
     position: relative;
     overflow: hidden;
+    -webkit-text-fill-color: rgb(0, 3, 6);
+
 }
 
 .vacation-slot-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent-color), #ff6b6b, #4ecdc4);
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 50, 0.5); /* adjust darkness */
+  border-radius: 20px;
+  z-index: 0; /* send overlay behind */
 }
+
+
+
 
 .vacation-slot-card:hover {
     transform: translateY(-8px) scale(1.02);
-    box-shadow: 0 8px 30px rgba(0,0,0,0.15);
+    box-shadow: 0 8px 30px rgba(249, 246, 246, 0.904);
 }
 
 .vacation-date h5 {
-    color: var(--accent-color);
+    color: #0a0000;
     font-weight: 600;
     font-size: 1.2rem;
 }
@@ -241,6 +258,7 @@
     
     .vacation-slot-card {
         margin-bottom: 1rem;
+        -webkit-text-fill-color: aliceblue;
     }
 }
 </style>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #376 

---

## Rationale for this change

This PR resolves a simple bug in which the text was not visible for the user in vacation spots region . 

The goal was to make the page visually cohesive and professional.

## What changes are included in this PR?

This fix includes the  visiblilty of text and also the pop up struture of header which will overall make interface better . 


## Are these changes tested?

Yes, the fix was manually tested by viewing  in the browser.


## 📷 Screenshots & Visual Documentation

Visual proof will be provided in the comments below.

---
## EntelligenceAI PR Summary 
 This PR updates the CSS styling for the vacation slots page, focusing on text colors, shadows, and visual overlays to enhance readability and visual appeal. Changes include adding white text color, text shadows, modifying card overlays, and adjusting hover effects. 

