### PR TITLE
[skip-screenshot] fix: updated the logo of wanderlust

### DIFF
--- a/views/users/achievements.ejs
+++ b/views/users/achievements.ejs
@@ -32,7 +32,7 @@ function getCategoryDescription(category) {
       --card-bg-alt: rgba(255, 255, 255, 0.98);
       --text-primary: #2c3e50;
       --text-secondary: #7f8c8d;
-       --accent-color: #3498db;
+       --accent-color: #db3434;
        --success-color: #27ae60;
       --warning-color: #f39c12;
        --danger-color: #e74c3c;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #372 

---

## Rationale for this change

This logo of wanderLust was not as same color like on other pages + it was not flattering and it was a little invisible with the theme .

## What changes are included in this PR?

This fix primarily involves updating the CSS . 

## Are these changes tested?

Yes, the fix was manually tested by viewing in the browser.


## 📷 Screenshots & Visual Documentation

Visual proof of the synchronized logo will be provided in the comments below.